### PR TITLE
docs: add pnpm installation steps to README (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 ## Getting Started
 
-First, run the development server:
+Install `pnpm` if missing: <https://pnpm.io/installation>
 
 ```bash
+# install dependencies
+pnpm install
+
+# start dev server
 pnpm run dev
 ```
 


### PR DESCRIPTION
Added steps for installing `pnpm` to the project's `README`. This ensures developers can quickly get started with the appropriate package manager. No functional changes were made.

resolves #34 