### PR TITLE
Feat/#33=add drizzle schema

### DIFF
--- a/drizzle/0001_serious_raider.sql
+++ b/drizzle/0001_serious_raider.sql
@@ -1,0 +1,85 @@
+CREATE TABLE "address" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "address_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"city" text NOT NULL,
+	"street" text NOT NULL,
+	"building" text NOT NULL,
+	"apartment" text,
+	"zip_code" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "organization" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "organization_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"krs" text NOT NULL,
+	"main_address_id" integer NOT NULL,
+	"phone_number" text NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	CONSTRAINT "organization_user_id_unique" UNIQUE("user_id"),
+	CONSTRAINT "organization_krs_unique" UNIQUE("krs")
+);
+--> statement-breakpoint
+CREATE TABLE "organization_shipping_address" (
+	"organization_id" integer NOT NULL,
+	"address_id" integer NOT NULL,
+	CONSTRAINT "organization_shipping_address_organization_id_address_id_pk" PRIMARY KEY("organization_id","address_id")
+);
+--> statement-breakpoint
+CREATE TABLE "donor" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "donor_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	CONSTRAINT "donor_user_id_unique" UNIQUE("user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "donor_favourite_need" (
+	"donor_id" integer NOT NULL,
+	"need_id" integer NOT NULL,
+	CONSTRAINT "donor_favourite_need_donor_id_need_id_pk" PRIMARY KEY("donor_id","need_id")
+);
+--> statement-breakpoint
+CREATE TABLE "need" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "need_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"organization_id" integer NOT NULL,
+	"delivery_address_id" integer NOT NULL,
+	"description" text NOT NULL,
+	"beneficiary_name" text NOT NULL,
+	"requested_item" text NOT NULL,
+	"photo" text,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "need_status_history" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "need_status_history_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"need_id" integer NOT NULL,
+	"to_status" text NOT NULL,
+	"changed_by_user_id" text NOT NULL,
+	"changed_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "donation" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "donation_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"donor_id" integer NOT NULL,
+	"need_id" integer NOT NULL,
+	"status" text NOT NULL,
+	"booked_at" timestamp NOT NULL,
+	"fulfilled_at" timestamp
+);
+--> statement-breakpoint
+ALTER TABLE "organization" ADD CONSTRAINT "organization_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization" ADD CONSTRAINT "organization_main_address_id_address_id_fk" FOREIGN KEY ("main_address_id") REFERENCES "public"."address"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_shipping_address" ADD CONSTRAINT "organization_shipping_address_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_shipping_address" ADD CONSTRAINT "organization_shipping_address_address_id_address_id_fk" FOREIGN KEY ("address_id") REFERENCES "public"."address"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "donor" ADD CONSTRAINT "donor_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "donor_favourite_need" ADD CONSTRAINT "donor_favourite_need_donor_id_donor_id_fk" FOREIGN KEY ("donor_id") REFERENCES "public"."donor"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "donor_favourite_need" ADD CONSTRAINT "donor_favourite_need_need_id_need_id_fk" FOREIGN KEY ("need_id") REFERENCES "public"."need"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "need" ADD CONSTRAINT "need_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "need" ADD CONSTRAINT "need_delivery_address_id_address_id_fk" FOREIGN KEY ("delivery_address_id") REFERENCES "public"."address"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "need_status_history" ADD CONSTRAINT "need_status_history_need_id_need_id_fk" FOREIGN KEY ("need_id") REFERENCES "public"."need"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "need_status_history" ADD CONSTRAINT "need_status_history_changed_by_user_id_user_id_fk" FOREIGN KEY ("changed_by_user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "donation" ADD CONSTRAINT "donation_donor_id_donor_id_fk" FOREIGN KEY ("donor_id") REFERENCES "public"."donor"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "donation" ADD CONSTRAINT "donation_need_id_need_id_fk" FOREIGN KEY ("need_id") REFERENCES "public"."need"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,941 @@
+{
+  "id": "df0c3f40-b4d4-4d8e-acca-f24514bda18f",
+  "prevId": "0cf62093-892c-44cb-8a7f-b477120adfc6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.address": {
+      "name": "address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "address_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "building": {
+          "name": "building",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apartment": {
+          "name": "apartment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "krs": {
+          "name": "krs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_address_id": {
+          "name": "main_address_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_user_id_user_id_fk": {
+          "name": "organization_user_id_user_id_fk",
+          "tableFrom": "organization",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_main_address_id_address_id_fk": {
+          "name": "organization_main_address_id_address_id_fk",
+          "tableFrom": "organization",
+          "tableTo": "address",
+          "columnsFrom": ["main_address_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_user_id_unique": {
+          "name": "organization_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        },
+        "organization_krs_unique": {
+          "name": "organization_krs_unique",
+          "nullsNotDistinct": false,
+          "columns": ["krs"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_shipping_address": {
+      "name": "organization_shipping_address",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_shipping_address_organization_id_organization_id_fk": {
+          "name": "organization_shipping_address_organization_id_organization_id_fk",
+          "tableFrom": "organization_shipping_address",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_shipping_address_address_id_address_id_fk": {
+          "name": "organization_shipping_address_address_id_address_id_fk",
+          "tableFrom": "organization_shipping_address",
+          "tableTo": "address",
+          "columnsFrom": ["address_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_shipping_address_organization_id_address_id_pk": {
+          "name": "organization_shipping_address_organization_id_address_id_pk",
+          "columns": ["organization_id", "address_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donor": {
+      "name": "donor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "donor_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "donor_user_id_user_id_fk": {
+          "name": "donor_user_id_user_id_fk",
+          "tableFrom": "donor",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "donor_user_id_unique": {
+          "name": "donor_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donor_favourite_need": {
+      "name": "donor_favourite_need",
+      "schema": "",
+      "columns": {
+        "donor_id": {
+          "name": "donor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "need_id": {
+          "name": "need_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "donor_favourite_need_donor_id_donor_id_fk": {
+          "name": "donor_favourite_need_donor_id_donor_id_fk",
+          "tableFrom": "donor_favourite_need",
+          "tableTo": "donor",
+          "columnsFrom": ["donor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "donor_favourite_need_need_id_need_id_fk": {
+          "name": "donor_favourite_need_need_id_need_id_fk",
+          "tableFrom": "donor_favourite_need",
+          "tableTo": "need",
+          "columnsFrom": ["need_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "donor_favourite_need_donor_id_need_id_pk": {
+          "name": "donor_favourite_need_donor_id_need_id_pk",
+          "columns": ["donor_id", "need_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.need": {
+      "name": "need",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "need_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_address_id": {
+          "name": "delivery_address_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beneficiary_name": {
+          "name": "beneficiary_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_item": {
+          "name": "requested_item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "need_organization_id_organization_id_fk": {
+          "name": "need_organization_id_organization_id_fk",
+          "tableFrom": "need",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "need_delivery_address_id_address_id_fk": {
+          "name": "need_delivery_address_id_address_id_fk",
+          "tableFrom": "need",
+          "tableTo": "address",
+          "columnsFrom": ["delivery_address_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.need_status_history": {
+      "name": "need_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "need_status_history_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "need_id": {
+          "name": "need_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "need_status_history_need_id_need_id_fk": {
+          "name": "need_status_history_need_id_need_id_fk",
+          "tableFrom": "need_status_history",
+          "tableTo": "need",
+          "columnsFrom": ["need_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "need_status_history_changed_by_user_id_user_id_fk": {
+          "name": "need_status_history_changed_by_user_id_user_id_fk",
+          "tableFrom": "need_status_history",
+          "tableTo": "user",
+          "columnsFrom": ["changed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donation": {
+      "name": "donation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "donation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "donor_id": {
+          "name": "donor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "need_id": {
+          "name": "need_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booked_at": {
+          "name": "booked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfilled_at": {
+          "name": "fulfilled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "donation_donor_id_donor_id_fk": {
+          "name": "donation_donor_id_donor_id_fk",
+          "tableFrom": "donation",
+          "tableTo": "donor",
+          "columnsFrom": ["donor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "donation_need_id_need_id_fk": {
+          "name": "donation_need_id_need_id_fk",
+          "tableFrom": "donation",
+          "tableTo": "need",
+          "columnsFrom": ["need_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1773488100956,
       "tag": "0000_glorious_colleen_wing",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1781374056251,
+      "tag": "0001_serious_raider",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/db.smoke.integration.test.ts
+++ b/src/db/db.smoke.integration.test.ts
@@ -10,6 +10,17 @@ import {
 
 import { createAuthIntegrationHarness } from '../test/auth-integration/harness';
 
+const DOMAIN_TABLES = [
+  'address',
+  'donation',
+  'donor',
+  'donor_favourite_need',
+  'need',
+  'need_status_history',
+  'organization',
+  'organization_shipping_address',
+] as const;
+
 describe('database integration', () => {
   let harness: Awaited<ReturnType<typeof createAuthIntegrationHarness>>;
 
@@ -36,6 +47,12 @@ describe('database integration', () => {
       'user',
       'verification',
     ]);
+  });
+
+  it('migrates the container database and creates the domain tables', async () => {
+    await expect(harness.listExistingTables(DOMAIN_TABLES)).resolves.toEqual(
+      DOMAIN_TABLES,
+    );
   });
 
   it('imports the production db and auth singletons after test env setup', async () => {

--- a/src/db/schema/address.ts
+++ b/src/db/schema/address.ts
@@ -1,0 +1,10 @@
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+
+export const address = pgTable('address', {
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  city: text('city').notNull(),
+  street: text('street').notNull(),
+  building: text('building').notNull(),
+  apartment: text('apartment'),
+  zipCode: text('zip_code').notNull(),
+});

--- a/src/db/schema/auth.ts
+++ b/src/db/schema/auth.ts
@@ -1,6 +1,10 @@
 import { relations } from 'drizzle-orm';
 import { pgTable, text, timestamp, boolean, index } from 'drizzle-orm/pg-core';
 
+import { donor } from './donor';
+import { needStatusHistory } from './need';
+import { organization } from './organization';
+
 export const user = pgTable('user', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
@@ -73,9 +77,12 @@ export const verification = pgTable(
   (table) => [index('verification_identifier_idx').on(table.identifier)],
 );
 
-export const userRelations = relations(user, ({ many }) => ({
+export const userRelations = relations(user, ({ many, one }) => ({
   sessions: many(session),
   accounts: many(account),
+  donorProfile: one(donor),
+  administeredOrganization: one(organization),
+  needStatusChanges: many(needStatusHistory),
 }));
 
 export const sessionRelations = relations(session, ({ one }) => ({

--- a/src/db/schema/donation.ts
+++ b/src/db/schema/donation.ts
@@ -1,0 +1,29 @@
+import { relations } from 'drizzle-orm';
+import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+import { donor } from './donor';
+import { need } from './need';
+
+export const donation = pgTable('donation', {
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  donorId: integer('donor_id')
+    .notNull()
+    .references(() => donor.id),
+  needId: integer('need_id')
+    .notNull()
+    .references(() => need.id),
+  status: text('status').notNull(),
+  bookedAt: timestamp('booked_at').notNull(),
+  fulfilledAt: timestamp('fulfilled_at'),
+});
+
+export const donationRelations = relations(donation, ({ one }) => ({
+  donor: one(donor, {
+    fields: [donation.donorId],
+    references: [donor.id],
+  }),
+  need: one(need, {
+    fields: [donation.needId],
+    references: [need.id],
+  }),
+}));

--- a/src/db/schema/donor.ts
+++ b/src/db/schema/donor.ts
@@ -1,0 +1,63 @@
+import { relations } from 'drizzle-orm';
+import {
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+} from 'drizzle-orm/pg-core';
+
+import { user } from './auth';
+import { donation } from './donation';
+import { need } from './need';
+
+export const donor = pgTable('donor', {
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  userId: text('user_id')
+    .notNull()
+    .unique()
+    .references(() => user.id),
+  name: text('name').notNull(),
+  createdAt: timestamp('created_at').notNull(),
+  updatedAt: timestamp('updated_at').notNull(),
+});
+
+export const donorFavouriteNeed = pgTable(
+  'donor_favourite_need',
+  {
+    donorId: integer('donor_id')
+      .notNull()
+      .references(() => donor.id),
+    needId: integer('need_id')
+      .notNull()
+      .references(() => need.id),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.donorId, table.needId],
+    }),
+  ],
+);
+
+export const donorRelations = relations(donor, ({ many, one }) => ({
+  user: one(user, {
+    fields: [donor.userId],
+    references: [user.id],
+  }),
+  donationCommitments: many(donation),
+  savedNeeds: many(donorFavouriteNeed),
+}));
+
+export const donorFavouriteNeedRelations = relations(
+  donorFavouriteNeed,
+  ({ one }) => ({
+    donor: one(donor, {
+      fields: [donorFavouriteNeed.donorId],
+      references: [donor.id],
+    }),
+    need: one(need, {
+      fields: [donorFavouriteNeed.needId],
+      references: [need.id],
+    }),
+  }),
+);

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,1 +1,6 @@
 export * from './auth';
+export * from './address';
+export * from './organization';
+export * from './donor';
+export * from './need';
+export * from './donation';

--- a/src/db/schema/need.ts
+++ b/src/db/schema/need.ts
@@ -1,0 +1,64 @@
+import { relations } from 'drizzle-orm';
+import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+import { address } from './address';
+import { user } from './auth';
+import { donation } from './donation';
+import { donorFavouriteNeed } from './donor';
+import { organization } from './organization';
+
+export const need = pgTable('need', {
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  organizationId: integer('organization_id')
+    .notNull()
+    .references(() => organization.id),
+  deliveryAddressId: integer('delivery_address_id')
+    .notNull()
+    .references(() => address.id),
+  description: text('description').notNull(),
+  beneficiaryName: text('beneficiary_name').notNull(),
+  requestedItem: text('requested_item').notNull(),
+  photo: text('photo'),
+  createdAt: timestamp('created_at').notNull(),
+  updatedAt: timestamp('updated_at').notNull(),
+});
+
+export const needStatusHistory = pgTable('need_status_history', {
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  needId: integer('need_id')
+    .notNull()
+    .references(() => need.id),
+  toStatus: text('to_status').notNull(),
+  changedByUserId: text('changed_by_user_id')
+    .notNull()
+    .references(() => user.id),
+  changedAt: timestamp('changed_at').notNull(),
+});
+
+export const needRelations = relations(need, ({ many, one }) => ({
+  organization: one(organization, {
+    fields: [need.organizationId],
+    references: [organization.id],
+  }),
+  deliveryAddress: one(address, {
+    fields: [need.deliveryAddressId],
+    references: [address.id],
+  }),
+  statusTimeline: many(needStatusHistory),
+  donationCommitments: many(donation),
+  savedByDonors: many(donorFavouriteNeed),
+}));
+
+export const needStatusHistoryRelations = relations(
+  needStatusHistory,
+  ({ one }) => ({
+    need: one(need, {
+      fields: [needStatusHistory.needId],
+      references: [need.id],
+    }),
+    changedBy: one(user, {
+      fields: [needStatusHistory.changedByUserId],
+      references: [user.id],
+    }),
+  }),
+);

--- a/src/db/schema/organization.ts
+++ b/src/db/schema/organization.ts
@@ -1,0 +1,75 @@
+import { relations } from 'drizzle-orm';
+import {
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+} from 'drizzle-orm/pg-core';
+
+import { user } from './auth';
+import { address } from './address';
+import { need } from './need';
+
+export const organization = pgTable('organization', {
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  userId: text('user_id')
+    .notNull()
+    .unique()
+    .references(() => user.id),
+  name: text('name').notNull(),
+  krs: text('krs').notNull().unique(),
+  mainAddressId: integer('main_address_id')
+    .notNull()
+    .references(() => address.id),
+  phoneNumber: text('phone_number').notNull(),
+  createdAt: timestamp('created_at').notNull(),
+  updatedAt: timestamp('updated_at').notNull(),
+});
+
+export const organizationShippingAddress = pgTable(
+  'organization_shipping_address',
+  {
+    organizationId: integer('organization_id')
+      .notNull()
+      .references(() => organization.id),
+    addressId: integer('address_id')
+      .notNull()
+      .references(() => address.id),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.organizationId, table.addressId],
+    }),
+  ],
+);
+
+export const organizationRelations = relations(
+  organization,
+  ({ many, one }) => ({
+    user: one(user, {
+      fields: [organization.userId],
+      references: [user.id],
+    }),
+    mainAddress: one(address, {
+      fields: [organization.mainAddressId],
+      references: [address.id],
+    }),
+    shippingAddresses: many(organizationShippingAddress),
+    publishedNeeds: many(need),
+  }),
+);
+
+export const organizationShippingAddressRelations = relations(
+  organizationShippingAddress,
+  ({ one }) => ({
+    organization: one(organization, {
+      fields: [organizationShippingAddress.organizationId],
+      references: [organization.id],
+    }),
+    address: one(address, {
+      fields: [organizationShippingAddress.addressId],
+      references: [address.id],
+    }),
+  }),
+);

--- a/src/write/domain/entities/donation.ts
+++ b/src/write/domain/entities/donation.ts
@@ -1,0 +1,14 @@
+import type { DonationId, DonorId, NeedId } from '@/write/domain/shared/ids';
+
+export type DonationStatus = 'BOOKED' | 'FULFILLED' | 'CANCELLED';
+
+export class Donation {
+  constructor(
+    private readonly id: DonationId,
+    private readonly donorId: DonorId,
+    private readonly needId: NeedId,
+    private readonly status: DonationStatus,
+    private readonly bookedAt: Date,
+    private readonly fulfilledAt?: Date,
+  ) {}
+}

--- a/src/write/domain/entities/donor.ts
+++ b/src/write/domain/entities/donor.ts
@@ -1,0 +1,13 @@
+import type { DonorId, NeedId, UserId } from '@/write/domain/shared/ids';
+
+export class Donor {
+  constructor(
+    private readonly id: DonorId,
+    private readonly userId: UserId,
+    private readonly name: string,
+    private readonly favouriteNeeds: readonly NeedId[],
+
+    private readonly createdAt: Date,
+    private readonly updatedAt: Date,
+  ) {}
+}

--- a/src/write/domain/entities/index.ts
+++ b/src/write/domain/entities/index.ts
@@ -1,0 +1,8 @@
+export { Donation } from '@/write/domain/entities/donation';
+export type { DonationStatus } from '@/write/domain/entities/donation';
+export { Donor } from '@/write/domain/entities/donor';
+export { Need } from '@/write/domain/entities/need';
+export type { NeedStatus } from '@/write/domain/entities/need';
+export { NeedStatusHistory } from '@/write/domain/entities/need-status-history';
+export { Organization } from '@/write/domain/entities/organization';
+export { User } from '@/write/domain/entities/user';

--- a/src/write/domain/entities/need-status-history.ts
+++ b/src/write/domain/entities/need-status-history.ts
@@ -1,0 +1,11 @@
+import type { NeedStatusHistoryId, UserId } from '@/write/domain/shared/ids';
+import type { NeedStatus } from '@/write/domain/entities/need';
+
+export class NeedStatusHistory {
+  constructor(
+    private readonly id: NeedStatusHistoryId,
+    private readonly toStatus: NeedStatus,
+    private readonly changedByUserId: UserId,
+    private readonly changedAt: Date,
+  ) {}
+}

--- a/src/write/domain/entities/need.ts
+++ b/src/write/domain/entities/need.ts
@@ -1,0 +1,21 @@
+import type { OrganizationId, NeedId } from '@/write/domain/shared/ids';
+import type { NeedStatusHistory } from '@/write/domain/entities/need-status-history';
+import type { Address } from '@/write/domain/value-objects';
+
+export type NeedStatus = 'ACTIVE' | 'FULFILLED';
+
+export class Need {
+  constructor(
+    private readonly id: NeedId,
+    private readonly organizationId: OrganizationId,
+    private readonly deliveryAddress: Address,
+    private readonly description: string,
+    private readonly beneficiaryName: string,
+    private readonly requestedItem: string,
+    private readonly statusTimeline: readonly NeedStatusHistory[],
+
+    private readonly createdAt: Date,
+    private readonly updatedAt: Date,
+    private readonly photo?: string,
+  ) {}
+}

--- a/src/write/domain/entities/organization.ts
+++ b/src/write/domain/entities/organization.ts
@@ -1,0 +1,17 @@
+import type { OrganizationId, UserId } from '@/write/domain/shared/ids';
+import type { Address, PhoneNumber } from '@/write/domain/value-objects';
+
+export class Organization {
+  constructor(
+    private readonly id: OrganizationId,
+    private readonly userId: UserId,
+    private readonly name: string,
+    private readonly krs: string,
+    private readonly mainAddress: Address,
+    private readonly shippingAddresses: readonly Address[],
+    private readonly phoneNumber: PhoneNumber,
+
+    private readonly createdAt: Date,
+    private readonly updatedAt: Date,
+  ) {}
+}

--- a/src/write/domain/entities/user.ts
+++ b/src/write/domain/entities/user.ts
@@ -1,0 +1,8 @@
+import type { UserId } from '@/write/domain/shared/ids';
+
+export class User {
+  constructor(
+    private readonly id: UserId,
+    private readonly email: string,
+  ) {}
+}

--- a/src/write/domain/index.ts
+++ b/src/write/domain/index.ts
@@ -1,0 +1,3 @@
+export * from '@/write/domain/entities';
+export type * from '@/write/domain/shared/ids';
+export * from '@/write/domain/value-objects';

--- a/src/write/domain/shared/brand.ts
+++ b/src/write/domain/shared/brand.ts
@@ -1,0 +1,3 @@
+export type Brand<T, Name extends string> = T & {
+  readonly __brand: Name;
+};

--- a/src/write/domain/shared/ids.ts
+++ b/src/write/domain/shared/ids.ts
@@ -1,0 +1,13 @@
+import type { Brand } from '@/write/domain/shared/brand';
+
+export type UserId = Brand<string, 'UserId'>;
+
+export type OrganizationId = Brand<number, 'OrganizationId'>;
+
+export type DonorId = Brand<number, 'DonorId'>;
+
+export type NeedId = Brand<number, 'NeedId'>;
+
+export type DonationId = Brand<number, 'DonationId'>;
+
+export type NeedStatusHistoryId = Brand<number, 'NeedStatusHistoryId'>;

--- a/src/write/domain/value-objects/address.ts
+++ b/src/write/domain/value-objects/address.ts
@@ -1,0 +1,9 @@
+export class Address {
+  constructor(
+    public readonly city: string,
+    public readonly street: string,
+    public readonly building: string,
+    public readonly zipCode: string,
+    public readonly apartment?: string,
+  ) {}
+}

--- a/src/write/domain/value-objects/index.ts
+++ b/src/write/domain/value-objects/index.ts
@@ -1,0 +1,2 @@
+export { Address } from '@/write/domain/value-objects/address';
+export { PhoneNumber } from '@/write/domain/value-objects/phone-number';

--- a/src/write/domain/value-objects/phone-number.ts
+++ b/src/write/domain/value-objects/phone-number.ts
@@ -1,0 +1,3 @@
+export class PhoneNumber {
+  constructor(public readonly value: string) {}
+}


### PR DESCRIPTION
## Domain Schema

- Added Drizzle schema for write-domain entities under `src/db/schema`, split by domain file.
- Domain tables reference the existing Better Auth `user.id` text column; auth schema itself remains unchanged.
- Status values stay as plain `text` columns, not database enums.
- Domain foreign keys do not define `onDelete`; domain timestamp columns have no DB defaults or update hooks and must be set by application code.
- Only default PK/unique/composite-key indexes are used for new domain tables; no extra secondary indexes or migrations were added.
- Updated `src/db/db.smoke.integration.test.ts` to check that the new domain tables are created by migrations.
- Verified with `pnpm type-check` and `pnpm test`.

## Domain Model

Added `src/write/domain` with plain data-bag entities and value objects. Creation, rehydration, and richer domain methods are deferred until concrete use cases need them.

## Discussions
### Domain Entity Location

Is `src/write/domain` fine for now, or should domain entities live somewhere else? I lean toward a structure that explicitly separates client and server code.

### Temporal vs Date

The write-domain model currently uses native [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) for timestamp fields. [`Temporal.Instant`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant) may be better long term, but [`Temporal`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) requires `@js-temporal/polyfill` plus explicit imports/mapping.

- Option 1: Keep the current decision for this pass: use `Date` to avoid introducing a polyfill, and revisit `Temporal.Instant` when persistence mapping and runtime support are discussed.
- Option 2: Switch domain timestamps to `Temporal.Instant` now and add the polyfill/mapping explicitly.

### Private Field Naming

Should private domain fields use plain names (`id`, `name`) or an underscore prefix (`_id`, `_name`), especially if getters are added later?


closes #33