### PR TITLE
[Landing Page] Populate Storybook with existing components (#62)

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,7 +1,5 @@
-import { Facebook, Linkedin, Mail } from 'lucide-react';
-
-import { Link } from '@/components/ui/link';
 import { PublicHeader } from '@/components/features/public-header';
+import { PublicFooter } from '@/components/features/public-footer';
 
 export default function PublicLayout({
   children,
@@ -12,71 +10,7 @@ export default function PublicLayout({
     <>
       <PublicHeader />
       <main>{children}</main>
-
-      <footer className="public-footer">
-        <div className="public-footer__top">
-          <div className="public-footer__brand">
-            <span className="public-footer__brand-dot" aria-hidden="true" />
-            <span className="public-footer__brand-name">Potrzebnik</span>
-          </div>
-
-          <div className="public-footer__contact">
-            <div className="public-footer__contact-group">
-              <h2 className="public-footer__heading">Skontaktuj się z nami</h2>
-              <Link
-                href="mailto:potrzebnik@mail.com"
-                className="public-footer__mail"
-              >
-                <Mail aria-hidden="true" />
-                <span>potrzebnik@mail.com</span>
-              </Link>
-            </div>
-
-            <div className="public-footer__social-group">
-              <h2 className="public-footer__heading">Obserwuj nas</h2>
-              <div className="public-footer__social-links">
-                <Link
-                  href="https://www.linkedin.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="LinkedIn"
-                >
-                  <Linkedin aria-hidden="true" />
-                </Link>
-                <Link
-                  href="https://www.facebook.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Facebook"
-                >
-                  <Facebook aria-hidden="true" />
-                </Link>
-              </div>
-            </div>
-          </div>
-
-          <nav className="public-footer__nav" aria-label="Nawigacja w stopce">
-            <Link href="/organizations" variant="footerNav">
-              Zgłoś organizację
-            </Link>
-            <Link href="/about" variant="footerNav">
-              O nas
-            </Link>
-            <Link href="/faqs" variant="footerNav">
-              Najczęściej zadawane pytania
-            </Link>
-          </nav>
-        </div>
-
-        <nav className="public-footer__legal" aria-label="Informacje prawne">
-          <Link href="/privacy-policy" variant="footerLegal">
-            Polityka prywatności
-          </Link>
-          <Link href="/terms" variant="footerLegal">
-            Regulamin serwisu
-          </Link>
-        </nav>
-      </footer>
+      <PublicFooter />
     </>
   );
 }

--- a/src/components/features/public-footer.stories.tsx
+++ b/src/components/features/public-footer.stories.tsx
@@ -8,7 +8,6 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
-  tags: ['autodocs'],
 } satisfies Meta<typeof PublicFooter>;
 
 export default meta;

--- a/src/components/features/public-footer.stories.tsx
+++ b/src/components/features/public-footer.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { PublicFooter } from '@/components/features/public-footer';
+
+const meta = {
+  title: 'Features/PublicFooter',
+  component: PublicFooter,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PublicFooter>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/features/public-footer.tsx
+++ b/src/components/features/public-footer.tsx
@@ -1,0 +1,72 @@
+import { Facebook, Linkedin, Mail } from 'lucide-react';
+
+import { Link } from '@/components/ui/link';
+
+export function PublicFooter() {
+  return (
+    <footer className="public-footer">
+      <div className="public-footer__top">
+        <div className="public-footer__brand">
+          <span className="public-footer__brand-dot" aria-hidden="true" />
+          <span className="public-footer__brand-name">Potrzebnik</span>
+        </div>
+
+        <div className="public-footer__contact">
+          <div className="public-footer__contact-group">
+            <h2 className="public-footer__heading">Skontaktuj się z nami</h2>
+            <Link
+              href="mailto:potrzebnik@mail.com"
+              className="public-footer__mail"
+            >
+              <Mail aria-hidden="true" />
+              <span>potrzebnik@mail.com</span>
+            </Link>
+          </div>
+
+          <div className="public-footer__social-group">
+            <h2 className="public-footer__heading">Obserwuj nas</h2>
+            <div className="public-footer__social-links">
+              <Link
+                href="https://www.linkedin.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="LinkedIn"
+              >
+                <Linkedin aria-hidden="true" />
+              </Link>
+              <Link
+                href="https://www.facebook.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Facebook"
+              >
+                <Facebook aria-hidden="true" />
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        <nav className="public-footer__nav" aria-label="Nawigacja w stopce">
+          <Link href="/organizations" variant="footerNav">
+            Zgłoś organizację
+          </Link>
+          <Link href="/about" variant="footerNav">
+            O nas
+          </Link>
+          <Link href="/faqs" variant="footerNav">
+            Najczęściej zadawane pytania
+          </Link>
+        </nav>
+      </div>
+
+      <nav className="public-footer__legal" aria-label="Informacje prawne">
+        <Link href="/privacy-policy" variant="footerLegal">
+          Polityka prywatności
+        </Link>
+        <Link href="/terms" variant="footerLegal">
+          Regulamin serwisu
+        </Link>
+      </nav>
+    </footer>
+  );
+}

--- a/src/components/features/public-header.stories.tsx
+++ b/src/components/features/public-header.stories.tsx
@@ -8,7 +8,6 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
-  tags: ['autodocs'],
 } satisfies Meta<typeof PublicHeader>;
 
 export default meta;

--- a/src/components/features/public-header.stories.tsx
+++ b/src/components/features/public-header.stories.tsx
@@ -16,7 +16,14 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Szeroki widok — wariant `hidden md:block` z nawigacją poziomą.
-export const Desktop: Story = {};
+// Viewport przypięty JAWNIE (≥ 768px): globalny viewport w UI jest "sticky"
+// między stories, więc bez tego `Desktop` odziedziczyłby wąski viewport po
+// obejrzeniu `Mobile` i pokazał mobilny layout.
+export const Desktop: Story = {
+  globals: {
+    viewport: { value: '1280-800' },
+  },
+};
 
 // Wąski widok — wariant `md:hidden` z przyciskiem hamburgera.
 // Viewport w formacie '{width}-{height}' (< 768px, poniżej breakpointu `md`).

--- a/src/components/features/public-header.stories.tsx
+++ b/src/components/features/public-header.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { PublicHeader } from '@/components/features/public-header';
+
+const meta = {
+  title: 'Features/PublicHeader',
+  component: PublicHeader,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PublicHeader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Szeroki widok — wariant `hidden md:block` z nawigacją poziomą.
+export const Desktop: Story = {};
+
+// Wąski widok — wariant `md:hidden` z przyciskiem hamburgera.
+// Viewport w formacie '{width}-{height}' (< 768px, poniżej breakpointu `md`).
+export const Mobile: Story = {
+  globals: {
+    viewport: { value: '390-844' },
+  },
+};

--- a/src/components/sections/AboutSection.stories.tsx
+++ b/src/components/sections/AboutSection.stories.tsx
@@ -8,7 +8,6 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
-  tags: ['autodocs'],
 } satisfies Meta<typeof AboutSection>;
 
 export default meta;

--- a/src/components/sections/AboutSection.stories.tsx
+++ b/src/components/sections/AboutSection.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import AboutSection from '@/components/sections/AboutSection';
+
+const meta = {
+  title: 'Sections/AboutSection',
+  component: AboutSection,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof AboutSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/sections/OrganizationsSection.stories.tsx
+++ b/src/components/sections/OrganizationsSection.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import OrganizationsSection from '@/components/sections/OrganizationsSection';
+
+const meta = {
+  title: 'Sections/OrganizationsSection',
+  component: OrganizationsSection,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof OrganizationsSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/sections/OrganizationsSection.stories.tsx
+++ b/src/components/sections/OrganizationsSection.stories.tsx
@@ -8,7 +8,6 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
-  tags: ['autodocs'],
 } satisfies Meta<typeof OrganizationsSection>;
 
 export default meta;

--- a/src/components/shared/ImageOverlay.stories.tsx
+++ b/src/components/shared/ImageOverlay.stories.tsx
@@ -8,7 +8,6 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'radio',

--- a/src/components/shared/ImageOverlay.stories.tsx
+++ b/src/components/shared/ImageOverlay.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import ImageOverlay from '@/components/shared/ImageOverlay';
+
+const meta = {
+  title: 'Shared/ImageOverlay',
+  component: ImageOverlay,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'radio',
+      options: ['yellow', 'blue', 'green'],
+    },
+  },
+  // Kształty są `absolute z-[-1]`, więc potrzebują pozycjonowanego, przezroczystego
+  // rodzica o ustalonym rozmiarze, żeby były widoczne w izolacji.
+  decorators: [
+    (Story) => (
+      <div className="relative h-64 w-96">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ImageOverlay>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Yellow: Story = {
+  args: { variant: 'yellow' },
+};
+
+export const Blue: Story = {
+  args: { variant: 'blue' },
+};
+
+export const Green: Story = {
+  args: { variant: 'green' },
+};

--- a/src/components/ui/button.stories.tsx
+++ b/src/components/ui/button.stories.tsx
@@ -9,7 +9,6 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',

--- a/src/components/ui/button.stories.tsx
+++ b/src/components/ui/button.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Plus } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+const meta = {
+  title: 'UI/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: [
+        'default',
+        'destructive',
+        'outline',
+        'secondary',
+        'ghost',
+        'link',
+      ],
+    },
+    size: {
+      control: 'select',
+      options: [
+        'default',
+        'xs',
+        'sm',
+        'lg',
+        'icon',
+        'icon-xs',
+        'icon-sm',
+        'icon-lg',
+      ],
+    },
+  },
+  args: {
+    children: 'Button',
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Secondary: Story = {
+  args: { variant: 'secondary' },
+};
+
+export const Destructive: Story = {
+  args: { variant: 'destructive' },
+};
+
+export const Outline: Story = {
+  args: { variant: 'outline' },
+};
+
+export const Ghost: Story = {
+  args: { variant: 'ghost' },
+};
+
+export const LinkVariant: Story = {
+  args: { variant: 'link' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-3">
+      <Button {...args} size="sm">
+        Small
+      </Button>
+      <Button {...args} size="default">
+        Default
+      </Button>
+      <Button {...args} size="lg">
+        Large
+      </Button>
+    </div>
+  ),
+};
+
+export const WithIcon: Story = {
+  args: {
+    size: 'icon',
+    'aria-label': 'Dodaj',
+    children: <Plus />,
+  },
+};

--- a/src/components/ui/link.stories.tsx
+++ b/src/components/ui/link.stories.tsx
@@ -8,7 +8,6 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'radio',

--- a/src/components/ui/link.stories.tsx
+++ b/src/components/ui/link.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Link } from '@/components/ui/link';
+
+const meta = {
+  title: 'UI/Link',
+  component: Link,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'radio',
+      options: ['default', 'footerNav', 'footerLegal'],
+    },
+  },
+  args: {
+    href: '#',
+    children: 'Link',
+  },
+} satisfies Meta<typeof Link>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const FooterNav: Story = {
+  args: {
+    variant: 'footerNav',
+    children: 'O nas',
+  },
+};
+
+export const FooterLegal: Story = {
+  args: {
+    variant: 'footerLegal',
+    children: 'Polityka prywatności',
+  },
+};


### PR DESCRIPTION
Dodaje stories dla realnych komponentów aplikacji, tak by Storybook — główny harness testowy komponentów wg `CLAUDE.md` (każda `*.stories.*` odpalana w headless Chromium przez `@vitest/browser-playwright`) — pokrywał faktyczny kod, a nie tylko scaffold.

## Nowe stories
| Story | Zakres |
|---|---|
| `UI/Button` | warianty, rozmiary, WithIcon, Disabled |
| `UI/Link` | default / footerNav / footerLegal |
| `Features/PublicHeader` | Desktop + Mobile |
| `Features/PublicFooter` | Default |
| `Shared/ImageOverlay` | warianty yellow / blue / green |
| `Sections/AboutSection`, `Sections/OrganizationsSection` | Default |

Footer był inline w `(public)/layout.tsx` — **wyciągnięty** do `components/features/public-footer.tsx` (`PublicFooter`) i podmieniony w layoucie, żeby dało się go ostorybookować (zgodnie z issue).

## Napotkane problemy / decyzje

1. **Nieaktualny lokalny `main`.** Pierwsza analiza była robiona ze starego lokalnego `main`, na którym `ImageOverlay` / `AboutSection` / `OrganizationsSection` jeszcze nie istniały — issue wyglądało na rozjechane z repo. Po synchronizacji z `origin/main` okazało się, że komponenty już są; branch odbity ze świeżego `origin/main` (lokalny commit-duplikat fixa porzucony).

2. **`PublicHeader` bez interaktywnego `play()`.** Header ma warianty responsywne (`md:hidden` / `hidden md:block`), a mobilny przycisk menu żyje w bloku `md:hidden`. W trybie vitest-browser story renderuje się **bez iframe**, więc Tailwindowe `md:` (media query na szerokości *okna*, nie kontenera) nie reagują na ustawiony viewport — hamburger pozostaje `display:none`, przez co `play()` otwierający menu byłby niestabilny/failujący. Zamiast tego dwie solidne render-stories: `Desktop` oraz `Mobile` (viewport `390-844`).

3. **`ImageOverlay`** renderuje kształty `absolute z-[-1]`, więc w izolacji dostał decorator z pozycjonowanym, przezroczystym boxem (`relative h-64 w-96`) — inaczej nie byłyby widoczne.

## Weryfikacja
- `pnpm exec vitest run` → **34/34** w headless Chromium (nowe: 20)
- `pnpm storybook:build` → OK
- `tsc` / `eslint` czyste na zmienionych plikach (pozostałe błędy tsc to pre-existing braki `better-auth` / testcontainers, niepowiązane)

## Uwaga
Scaffold `src/stories/Button|Header|Page` świadomie zostawiony — issue sugeruje usunięcie „eventually", do osobnego PR.