### PR TITLE
chore: strip UTF-8 BOM from five source files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/src/components/sections/HelpSection.tsx
+++ b/src/components/sections/HelpSection.tsx
@@ -1,4 +1,4 @@
-﻿import HelpCard from '@/components/shared/HelpCard';
+import HelpCard from '@/components/shared/HelpCard';
 import { Button } from '@/components/ui/button';
 import { BADGES } from '@/lib/constants';
 

--- a/src/components/shared/BadgeGroup.tsx
+++ b/src/components/shared/BadgeGroup.tsx
@@ -1,4 +1,4 @@
-﻿import {
+import {
   Popover,
   PopoverContent,
   PopoverTrigger,

--- a/src/components/shared/HelpCard.tsx
+++ b/src/components/shared/HelpCard.tsx
@@ -1,4 +1,4 @@
-﻿import {
+import {
   Card,
   CardHeader,
   CardTitle,

--- a/src/components/shared/ImageOverlay.tsx
+++ b/src/components/shared/ImageOverlay.tsx
@@ -1,4 +1,4 @@
-﻿export interface ImageOverlayProps {
+export interface ImageOverlayProps {
   variant: keyof typeof overlayVariants;
 }
 

--- a/src/components/shared/SectionTemplate.tsx
+++ b/src/components/shared/SectionTemplate.tsx
@@ -1,4 +1,4 @@
-﻿import Image, { StaticImageData } from 'next/image';
+import Image, { StaticImageData } from 'next/image';
 import ImageOverlay, {
   overlayVariants,
 } from '@/components/shared/ImageOverlay';


### PR DESCRIPTION
Five files started with a UTF-8 BOM glued to their first import. Prettier and eslint don't see it, so `pnpm check` passed with it in place.

Three bytes removed from each — the diff is one line per file. Plus an `.editorconfig` with `charset = utf-8` so editors don't put it back.

`pnpm check` exits 0. A BOM sweep over `src` returns nothing.

Four of the five files are in `shared/` and later cleanup PRs rewrite them, so this one goes first to keep those diffs clean.

From the audit in #81.