### PR TITLE
test(ui): add stories for badge, card and popover (#91)

### DIFF
--- a/src/components/ui/badge.stories.tsx
+++ b/src/components/ui/badge.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Badge } from '@/components/ui/badge';
+
+const meta = {
+  title: 'UI/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: [
+        'default',
+        'secondary',
+        'destructive',
+        'outline',
+        'ghost',
+        'link',
+      ],
+    },
+  },
+  args: {
+    children: 'Pilne',
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Secondary: Story = {
+  args: { variant: 'secondary' },
+};
+
+export const Destructive: Story = {
+  args: { variant: 'destructive' },
+};
+
+export const Outline: Story = {
+  args: { variant: 'outline' },
+};
+
+export const Ghost: Story = {
+  args: { variant: 'ghost' },
+};
+
+export const LinkVariant: Story = {
+  args: { variant: 'link' },
+};
+
+export const AsChildAnchor: Story = {
+  args: {
+    asChild: true,
+    variant: 'outline',
+    children: <a href="#organizacje">Zobacz organizacje</a>,
+  },
+};
+
+export const AllVariants: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge {...args} variant="default">
+        Default
+      </Badge>
+      <Badge {...args} variant="secondary">
+        Secondary
+      </Badge>
+      <Badge {...args} variant="destructive">
+        Destructive
+      </Badge>
+      <Badge {...args} variant="outline">
+        Outline
+      </Badge>
+      <Badge {...args} variant="ghost">
+        Ghost
+      </Badge>
+      <Badge {...args} variant="link">
+        Link
+      </Badge>
+    </div>
+  ),
+};

--- a/src/components/ui/card.stories.tsx
+++ b/src/components/ui/card.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+const meta = {
+  title: 'UI/Card',
+  component: Card,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    className: 'w-80',
+  },
+} satisfies Meta<typeof Card>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Full: Story = {
+  args: {
+    children: (
+      <>
+        <CardHeader>
+          <CardTitle>Paczki żywnościowe</CardTitle>
+          <CardDescription>Fundacja Dobry Start — Wrocław</CardDescription>
+          <CardAction>
+            <Button variant="ghost" size="sm">
+              Szczegóły
+            </Button>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          Zbieramy 200 paczek z produktami o długim terminie ważności dla rodzin
+          objętych wsparciem świetlicy.
+        </CardContent>
+        <CardFooter>
+          <Button>Wspieram</Button>
+        </CardFooter>
+      </>
+    ),
+  },
+};
+
+export const Minimal: Story = {
+  args: {
+    children: (
+      <CardContent>
+        Karta z samą treścią — bez nagłówka, akcji i stopki.
+      </CardContent>
+    ),
+  },
+};

--- a/src/components/ui/popover.stories.tsx
+++ b/src/components/ui/popover.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+
+const meta = {
+  title: 'UI/Popover',
+  component: Popover,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    children: (
+      <>
+        <PopoverTrigger asChild>
+          <Button variant="outline">Pozostałe potrzeby</Button>
+        </PopoverTrigger>
+        <PopoverContent aria-labelledby="popover-story-title">
+          <PopoverHeader>
+            <PopoverTitle id="popover-story-title">
+              Pozostałe potrzeby
+            </PopoverTitle>
+            <PopoverDescription>
+              Zgłoszone przez organizację w tym tygodniu.
+            </PopoverDescription>
+          </PopoverHeader>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Badge variant="outline">Żywność</Badge>
+            <Badge variant="outline">Środki czystości</Badge>
+            <Badge variant="outline">Odzież zimowa</Badge>
+          </div>
+        </PopoverContent>
+      </>
+    ),
+  },
+} satisfies Meta<typeof Popover>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  args: { defaultOpen: true },
+};
+
+export const Closed: Story = {
+  args: { defaultOpen: false },
+};


### PR DESCRIPTION
Closes #91.

`badge`, `card` and `popover` had no stories, and stories are this repo's main component test harness. #90 will change the `cva` in `badge.tsx` across three call sites — without these it goes in blind.

Three new files, primitives untouched. Badge: one story per `cva` variant plus `asChild`. Card: full composition and a minimal one. Popover: `defaultOpen`, so the test can see the portalled content.

`pnpm test:storybook`: 52 tests across 17 files, up from 40 across 14. `pnpm check` exits 0.

Worth knowing: the a11y addon is set to `test: 'todo'`, so a green check does **not** prove there are no axe violations. These stories were checked separately with `test: 'error'` — 12/12 pass.

Found while writing them, not fixed here: `PopoverTitle` is typed as `h2` but renders a `div`, and `PopoverContent` doesn't wire itself to the title via `aria-labelledby`, which breaks `aria-dialog-name`.