### PR TITLE
refactor(ui): extract shared BrandMark used by header and footer

### DIFF
--- a/src/components/features/public-footer.tsx
+++ b/src/components/features/public-footer.tsx
@@ -7,7 +7,7 @@ export function PublicFooter() {
   return (
     <footer className="text-footer-fg before:border-footer-border after:border-footer-border [&_a:focus-visible]:outline-footer-border before:m-0 before:block before:border-t before:content-none after:m-0 after:mt-3.75 after:block after:border-t after:content-none lg:before:content-[''] lg:after:content-[''] [&_a]:text-inherit [&_a]:no-underline [&_a:focus-visible]:outline-2 [&_a:focus-visible]:outline-offset-2">
       <div className="border-footer-border bg-footer-bg flex flex-col items-start gap-16.25 border-t border-b px-12.5 py-12.5 pl-5 lg:grid lg:min-h-71.25 lg:grid-cols-[1fr_255px_255px] lg:items-start lg:gap-12.5 lg:border lg:border-t-0 lg:px-26.25 lg:py-8.75 lg:pb-15">
-        <BrandMark variant="footer" className="self-stretch" />
+        <BrandMark className="self-stretch" />
 
         <div className="flex w-full max-w-80 flex-col gap-17.5 lg:w-48.75 lg:max-w-none lg:gap-7.5 lg:justify-self-center">
           <div className="flex flex-col justify-center gap-3.75 lg:gap-6.25">

--- a/src/components/features/public-footer.tsx
+++ b/src/components/features/public-footer.tsx
@@ -1,20 +1,13 @@
 import { Facebook, Linkedin, Mail } from 'lucide-react';
 
+import BrandMark from '@/components/shared/BrandMark';
 import { Link } from '@/components/ui/link';
 
 export function PublicFooter() {
   return (
     <footer className="text-footer-fg before:border-footer-border after:border-footer-border [&_a:focus-visible]:outline-footer-border before:m-0 before:block before:border-t before:content-none after:m-0 after:mt-3.75 after:block after:border-t after:content-none lg:before:content-[''] lg:after:content-[''] [&_a]:text-inherit [&_a]:no-underline [&_a:focus-visible]:outline-2 [&_a:focus-visible]:outline-offset-2">
       <div className="border-footer-border bg-footer-bg flex flex-col items-start gap-16.25 border-t border-b px-12.5 py-12.5 pl-5 lg:grid lg:min-h-71.25 lg:grid-cols-[1fr_255px_255px] lg:items-start lg:gap-12.5 lg:border lg:border-t-0 lg:px-26.25 lg:py-8.75 lg:pb-15">
-        <div className="flex items-center gap-5 self-stretch">
-          <span
-            className="bg-footer-fg inline-block h-6.25 w-6.25 rounded-full"
-            aria-hidden="true"
-          />
-          <span className="text-xl leading-normal font-semibold">
-            Potrzebnik
-          </span>
-        </div>
+        <BrandMark variant="footer" className="self-stretch" />
 
         <div className="flex w-full max-w-80 flex-col gap-17.5 lg:w-48.75 lg:max-w-none lg:gap-7.5 lg:justify-self-center">
           <div className="flex flex-col justify-center gap-3.75 lg:gap-6.25">

--- a/src/components/features/public-header.tsx
+++ b/src/components/features/public-header.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { ChevronDown, Menu, X } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import BrandMark from '@/components/shared/BrandMark';
 import { Button } from '@/components/ui/button';
 
 const navigationItems = [
@@ -24,14 +25,8 @@ export function PublicHeader() {
       <div className="bg-header-bg-mobile relative md:hidden">
         <div className="relative flex h-[60px] items-center">
           <div className="flex h-9 w-full items-center justify-between px-5">
-            <Link
-              href="/"
-              className="text-header-fg flex h-9 items-center gap-[20px]"
-            >
-              <span className="bg-header-fg h-[25px] w-[25px] rounded-full" />
-              <span className="inline-flex h-[25px] items-center text-[20px] leading-none font-semibold">
-                Potrzebnik
-              </span>
+            <Link href="/" className="text-header-fg flex h-9 items-center">
+              <BrandMark variant="header" />
             </Link>
             <Button
               id="navi-bar-icon-mobile"
@@ -105,14 +100,8 @@ export function PublicHeader() {
       <div className="border-header-rule hidden border-b md:block">
         <div className="bg-header-bg mx-auto flex h-20 w-full max-w-[1440px] items-center justify-between gap-[15px] px-[100px] pt-5 pb-[25px]">
           <div className="flex h-9 w-[925px] items-center gap-[65px]">
-            <Link
-              href="/"
-              className="text-header-fg flex h-9 items-center gap-[20px]"
-            >
-              <span className="bg-header-fg h-[25px] w-[25px] rounded-full" />
-              <span className="text-[20px] leading-[25px] font-semibold">
-                Potrzebnik
-              </span>
+            <Link href="/" className="text-header-fg flex h-9 items-center">
+              <BrandMark variant="header" />
             </Link>
 
             <nav aria-label="Nawigacja główna">

--- a/src/components/features/public-header.tsx
+++ b/src/components/features/public-header.tsx
@@ -26,7 +26,7 @@ export function PublicHeader() {
         <div className="relative flex h-[60px] items-center">
           <div className="flex h-9 w-full items-center justify-between px-5">
             <Link href="/" className="text-header-fg flex h-9 items-center">
-              <BrandMark variant="header" />
+              <BrandMark />
             </Link>
             <Button
               id="navi-bar-icon-mobile"
@@ -101,7 +101,7 @@ export function PublicHeader() {
         <div className="bg-header-bg mx-auto flex h-20 w-full max-w-[1440px] items-center justify-between gap-[15px] px-[100px] pt-5 pb-[25px]">
           <div className="flex h-9 w-[925px] items-center gap-[65px]">
             <Link href="/" className="text-header-fg flex h-9 items-center">
-              <BrandMark variant="header" />
+              <BrandMark />
             </Link>
 
             <nav aria-label="Nawigacja główna">

--- a/src/components/shared/BrandMark.stories.tsx
+++ b/src/components/shared/BrandMark.stories.tsx
@@ -8,34 +8,23 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  argTypes: {
-    variant: {
-      control: 'select',
-      options: ['header', 'footer'],
-    },
-  },
-  args: {
-    variant: 'header',
-  },
 } satisfies Meta<typeof BrandMark>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Header: Story = {
-  args: { variant: 'header' },
-};
+export const Default: Story = {};
 
-export const Footer: Story = {
-  args: { variant: 'footer' },
-};
-
-export const BothVariants: Story = {
+export const TakesColourFromContext: Story = {
   render: () => (
     <div className="flex flex-col gap-5">
-      <BrandMark variant="header" />
-      <BrandMark variant="footer" />
+      <div className="text-header-fg bg-header-bg p-5">
+        <BrandMark />
+      </div>
+      <div className="text-footer-fg bg-footer-bg p-5">
+        <BrandMark />
+      </div>
     </div>
   ),
 };

--- a/src/components/shared/BrandMark.stories.tsx
+++ b/src/components/shared/BrandMark.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import BrandMark from '@/components/shared/BrandMark';
+
+const meta = {
+  title: 'Shared/BrandMark',
+  component: BrandMark,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['header', 'footer'],
+    },
+  },
+  args: {
+    variant: 'header',
+  },
+} satisfies Meta<typeof BrandMark>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Header: Story = {
+  args: { variant: 'header' },
+};
+
+export const Footer: Story = {
+  args: { variant: 'footer' },
+};
+
+export const BothVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-5">
+      <BrandMark variant="header" />
+      <BrandMark variant="footer" />
+    </div>
+  ),
+};

--- a/src/components/shared/BrandMark.tsx
+++ b/src/components/shared/BrandMark.tsx
@@ -1,28 +1,18 @@
 import { APP_NAME } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 
-const brandMarkVariants = {
-  header: { dot: 'bg-header-fg', wordmark: 'text-header-fg' },
-  footer: { dot: 'bg-footer-fg', wordmark: 'text-footer-fg' },
-} as const;
-
 interface BrandMarkProps {
-  variant: keyof typeof brandMarkVariants;
   className?: string;
 }
 
-export default function BrandMark({ variant, className }: BrandMarkProps) {
-  const { dot, wordmark } = brandMarkVariants[variant];
-
+export default function BrandMark({ className }: BrandMarkProps) {
   return (
     <span className={cn('inline-flex items-center gap-5', className)}>
       <span
-        className={cn('h-6.25 w-6.25 rounded-full', dot)}
+        className="h-6.25 w-6.25 rounded-full bg-current"
         aria-hidden="true"
       />
-      <span className={cn('text-xl leading-tight font-semibold', wordmark)}>
-        {APP_NAME}
-      </span>
+      <span className="text-xl leading-tight font-semibold">{APP_NAME}</span>
     </span>
   );
 }

--- a/src/components/shared/BrandMark.tsx
+++ b/src/components/shared/BrandMark.tsx
@@ -1,0 +1,28 @@
+import { APP_NAME } from '@/lib/constants';
+import { cn } from '@/lib/utils';
+
+const brandMarkVariants = {
+  header: { dot: 'bg-header-fg', wordmark: 'text-header-fg' },
+  footer: { dot: 'bg-footer-fg', wordmark: 'text-footer-fg' },
+} as const;
+
+interface BrandMarkProps {
+  variant: keyof typeof brandMarkVariants;
+  className?: string;
+}
+
+export default function BrandMark({ variant, className }: BrandMarkProps) {
+  const { dot, wordmark } = brandMarkVariants[variant];
+
+  return (
+    <span className={cn('inline-flex items-center gap-5', className)}>
+      <span
+        className={cn('h-6.25 w-6.25 rounded-full', dot)}
+        aria-hidden="true"
+      />
+      <span className={cn('text-xl leading-tight font-semibold', wordmark)}>
+        {APP_NAME}
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
The brand mark — the dot plus the "Potrzebnik" wordmark — was hand-written in three places, each spelling the same thing differently:

| where | dot | wordmark |
|---|---|---|
| `public-header.tsx:31` | `h-[25px] w-[25px]` | `text-[20px] leading-none` |
| `public-header.tsx:112` | `h-[25px] w-[25px]` | `text-[20px] leading-[25px]` |
| `public-footer.tsx:11` | `h-6.25 w-6.25` | `text-xl leading-normal` |

`h-[25px]` and `h-6.25` are the same 25px, `text-[20px]` and `text-xl` the same 20px. Only the colour token and the line height actually differed. All three hardcoded the string while `APP_NAME` existed and was used nowhere.

New `shared/BrandMark.tsx` plus stories, three call sites replaced. The variant is a `keyof typeof` map rather than `cva`, because it splits classes across two elements — and that map is the pattern already used in `shared/` (`overlayVariants`, `heightVariants`).

Line height is unified to `leading-tight` (1.25 = 25px at 20px), the only value that had been typed deliberately. The footer moves down from 1.5, so its glyphs stay put but that line's box is 5px shorter.

`pnpm check` exits 0, Storybook 43/43. `grep rounded-full` no longer finds a second place drawing the mark.

Out of scope: the CTA buttons, the mobile/desktop duplication in the header, the remaining Figma pixel values.