### PR TITLE
chore: board organisation, docs, and roadmap (#81)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @potrzebnik/devs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,11 @@ their contents here.
 - `src/db/resolve-database-url.ts` is the single source of the database connection URL, for both
   runtime and `drizzle.config.ts`. It **throws fast** on missing environment variables. Preserve
   that; never silently default a secret.
-- No raw colour literals in styles. Styling is Tailwind utility classes co-located in JSX — no
-  hand-written component CSS, no BEM classes. `.stylelintrc.json` enforces it.
+- No raw colour literals in styles. In **the Next app**, styling is Tailwind utility classes
+  co-located in JSX — no hand-written component CSS, no BEM classes. `.stylelintrc.json` enforces
+  it. The docs site under `./docs/site/` is not the Next app and does hand-write CSS: theme-level
+  colour tokens in `src/styles/custom.css` (the only file there allowed a hex literal), layout in a
+  scoped `<style>` in the component.
 - Stories are the primary component test harness. A change to a component is tested by its
   `*.stories.tsx`, which `vitest.config.ts` runs in a real browser.
 - Every image renders through `next/image`. A raw `<img>` or a CSS `url(/…)` breaks the published

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -22,6 +22,7 @@ export default defineConfig({
       ],
       sidebar: [
         { label: 'Getting started', link: '/' },
+        { label: 'Roadmap', link: '/roadmap/' },
         { label: 'Architecture', link: '/architecture/' },
         { label: 'Database', link: '/database/' },
         { label: 'Auth & OAuth', link: '/auth/' },
@@ -41,6 +42,7 @@ export default defineConfig({
         },
         { label: 'Testing', link: '/testing/' },
         { label: 'Contributing', link: '/contributing/' },
+        { label: 'Zasady współpracy', link: '/zasady-wspolpracy/' },
         {
           label: 'Agents & skills',
           items: [

--- a/docs/site/src/components/Roadmap.astro
+++ b/docs/site/src/components/Roadmap.astro
@@ -1,0 +1,372 @@
+---
+// The roadmap board. Import from a content page as:
+//   import Roadmap from '../../components/Roadmap.astro';
+//
+// Content comes from the `roadmap` collection (src/content/roadmap/roadmap.yml).
+// A node renders as title + status pill + issue links, and nothing else — every
+// explanation of what a column or a status means belongs in the surrounding
+// .mdx — which is why a goal renders its name, its count and its trailer, and
+// nothing else. Colour tokens live in src/styles/custom.css; no hex literal here.
+//
+// Two legends filter the board, on the two axes a node carries: category and
+// status. Within an axis a chip is exclusive — clicking it shows that value
+// alone, and clicking it again restores the whole axis. Across axes the two
+// combine, so a node shows when both its category and its status are active.
+// Each column's `done / total` recounts over what is left.
+import { getCollection } from 'astro:content';
+
+const goals = (await getCollection('roadmap')).sort((a, b) => a.data.order - b.data.order);
+
+// Also the display order inside a column: design first, then implementation,
+// then organization. The YAML keeps its own order; sorting is presentation.
+const CATEGORIES = ['design', 'implementation', 'organization'] as const;
+
+const STATUS_LABEL = {
+  planned: 'planned',
+  'in-progress': 'in progress',
+  done: 'done',
+} as const;
+
+const STATUSES = ['planned', 'in-progress', 'done'] as const;
+
+const issueHref = (n: number) => `https://github.com/potrzebnik/potrzebnik/issues/${n}`;
+
+// Legend counts are static; the per-column `done / total` is recomputed in the
+// browser as the filters are used, and rendered server-side for no-JS.
+const nodes = goals.flatMap((goal) => goal.data.nodes);
+const countBy = <T extends string>(values: readonly T[], of: (node: (typeof nodes)[number]) => string) =>
+  Object.fromEntries(values.map((v) => [v, nodes.filter((node) => of(node) === v).length])) as Record<T, number>;
+
+const categoryCount = countBy(CATEGORIES, (node) => node.category);
+const statusCount = countBy(STATUSES, (node) => node.status);
+---
+
+<div class="roadmap-root not-content">
+  <ul class="legend" aria-label="Filter by category" data-axis="category">
+    {
+      CATEGORIES.map((category) => (
+        <li data-category={category}>
+          <button type="button" aria-pressed="true" data-value={category}>
+            <span class="swatch" aria-hidden="true" />
+            {category}
+            <span class="count">{categoryCount[category]}</span>
+          </button>
+        </li>
+      ))
+    }
+  </ul>
+
+  <ul class="legend" aria-label="Filter by status" data-axis="status">
+    {
+      STATUSES.map((status) => (
+        <li data-status={status}>
+          <button type="button" aria-pressed="true" data-value={status}>
+            <span class="swatch" aria-hidden="true" />
+            {STATUS_LABEL[status]}
+            <span class="count">{statusCount[status]}</span>
+          </button>
+        </li>
+      ))
+    }
+  </ul>
+
+  <div class="board">
+    {
+      goals.map((goal) => (
+        <section class="column" aria-labelledby={`roadmap-${goal.id}`}>
+          <h2 id={`roadmap-${goal.id}`}>
+            <span>{goal.data.name}</span>
+            <span class="column-meta">
+              {goal.data.nodes.filter((n) => n.status === 'done').length} / {goal.data.nodes.length}
+            </span>
+          </h2>
+          {goal.data.target && <p class="column-target">Target: {goal.data.target}</p>}
+          <ul class="nodes">
+            {[...goal.data.nodes]
+              .sort((a, b) => CATEGORIES.indexOf(a.category) - CATEGORIES.indexOf(b.category))
+              .map((node) => (
+              <li class="node" data-category={node.category} data-status={node.status}>
+                <span class="node-name">{node.name}</span>
+                <span class="node-status">{STATUS_LABEL[node.status]}</span>
+                {node.note && <span class="node-note">{node.note}</span>}
+                {node.issues && (
+                  <span class="node-issues">
+                    {node.issues.map((issue) => (
+                      <a href={issueHref(issue)}>#{issue}</a>
+                    ))}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+          {goal.data.trailer && <p class="trailer">{goal.data.trailer}</p>}
+        </section>
+      ))
+    }
+  </div>
+</div>
+
+<style>
+  /* Category filter. Unpressed buttons dim rather than disappear, so the set of
+     categories stays legible whatever is filtered out. */
+  .legend {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0;
+    margin: 0 0 0.5rem;
+    font-size: var(--sl-text-sm);
+  }
+
+  .legend:last-of-type {
+    margin-bottom: 1.75rem;
+  }
+
+  .legend button {
+    font: inherit;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: none;
+    color: var(--sl-color-text);
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 999px;
+    padding: 0.1rem 0.75rem 0.1rem 0.6rem;
+    cursor: pointer;
+  }
+
+  .legend button[aria-pressed='false'] {
+    color: var(--sl-color-gray-3);
+    opacity: 0.55;
+  }
+
+  /* A square swatch reads category, a round one reads status, so the two rows
+     are not mistaken for one list of six things. */
+  .legend .swatch {
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 0.15rem;
+    background: var(--category-color);
+    display: inline-block;
+  }
+
+  .legend[data-axis='status'] .swatch {
+    border-radius: 50%;
+    background: var(--status-color);
+  }
+
+  .legend .count {
+    color: var(--sl-color-gray-3);
+    font-size: var(--sl-text-xs);
+  }
+
+  /* Columns read left to right on a wide screen and stack on a narrow one.
+     Never a sideways scroll: the board must be readable on a phone. */
+  .board {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: 1fr;
+  }
+
+  @media (min-width: 60rem) {
+    .board {
+      grid-template-columns: repeat(3, 1fr);
+      align-items: start;
+    }
+  }
+
+  .column {
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.5rem;
+    padding: 1rem 1.125rem 1.25rem;
+    background: var(--sl-color-bg-nav);
+  }
+
+  .column > h2 {
+    color: var(--sl-color-white);
+    font-size: var(--sl-text-h3);
+    margin: 0;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .column-meta {
+    color: var(--sl-color-gray-3);
+    font-size: var(--sl-text-xs);
+    font-weight: 400;
+    white-space: nowrap;
+  }
+
+  .column-target {
+    color: var(--sl-color-gray-3);
+    font-size: var(--sl-text-sm);
+    margin: 0.375rem 0 0;
+  }
+
+  .nodes {
+    list-style: none;
+    margin: 0.5rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 0.625rem;
+  }
+
+  /* The left border carries category; the pill carries status. Name on the
+     left, pill pushed right, note and issues wrapping onto their own lines. */
+  .node {
+    border-left: 3px solid var(--category-color, var(--sl-color-gray-5));
+    padding: 0.4rem 0 0.4rem 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    column-gap: 0.5rem;
+  }
+
+  .node[hidden] {
+    display: none;
+  }
+
+  .node-name {
+    color: var(--sl-color-white);
+    font-weight: 600;
+    font-size: var(--sl-text-sm);
+    /* Take the remaining width and wrap internally, so a long name never
+       pushes the status pill onto a line of its own. */
+    flex: 1 1 55%;
+    min-width: 0;
+  }
+
+  .node-status {
+    color: var(--status-color, var(--sl-color-gray-3));
+    border: 1px solid var(--status-color, var(--sl-color-gray-5));
+    border-radius: 999px;
+    padding: 0.05rem 0.5rem;
+    font-size: var(--sl-text-xs);
+    line-height: 1.4;
+    margin: 0.125rem 0 0.125rem auto;
+    white-space: nowrap;
+  }
+
+  /* Status keeps all three channels — colour, text and a glyph — so it still
+     reads in greyscale or in print. Category is colour-only by decision. */
+  .node[data-status='done'] .node-status::before {
+    content: '\2713\00a0';
+  }
+
+  .node[data-status='in-progress'] .node-status::before {
+    content: '\25D0\00a0';
+  }
+
+  .node[data-status='planned'] .node-status::before {
+    content: '\25CB\00a0';
+  }
+
+  .node-note,
+  .node-issues {
+    flex-basis: 100%;
+  }
+
+  .node-note {
+    color: var(--sl-color-gray-3);
+    font-size: var(--sl-text-xs);
+    margin-top: 0.125rem;
+  }
+
+  .node-issues {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .node a {
+    color: var(--sl-color-accent-high);
+    font-size: var(--sl-text-xs);
+  }
+
+  .trailer {
+    color: var(--sl-color-gray-3);
+    font-size: var(--sl-text-sm);
+    font-style: italic;
+    margin: 1rem 0 0;
+  }
+
+  /* The one place category and status names bind to their tokens. */
+  [data-category='design'] {
+    --category-color: var(--roadmap-category-design);
+  }
+
+  [data-category='implementation'] {
+    --category-color: var(--roadmap-category-implementation);
+  }
+
+  [data-category='organization'] {
+    --category-color: var(--roadmap-category-organization);
+  }
+
+  [data-status='done'] {
+    --status-color: var(--roadmap-status-done);
+  }
+
+  [data-status='in-progress'] {
+    --status-color: var(--roadmap-status-in-progress);
+  }
+
+  [data-status='planned'] {
+    --status-color: var(--sl-color-gray-3);
+  }
+</style>
+
+<script>
+  // Progressive enhancement: without JS the board renders whole, which is the
+  // honest default. With JS the two legends filter it on their own axis, and
+  // each column's `done / total` recounts over what is left visible.
+  const root = document.querySelector<HTMLElement>('.roadmap-root');
+  if (root) {
+    const legends = [...root.querySelectorAll<HTMLElement>('.legend')].map((legend) => ({
+      // `category` | `status` — also the node dataset key the axis filters on.
+      axis: legend.dataset.axis as 'category' | 'status',
+      buttons: [...legend.querySelectorAll<HTMLButtonElement>('button')],
+    }));
+
+    const apply = () => {
+      // A node survives only if it is active on *every* axis.
+      const active = legends.map(({ axis, buttons }) => ({
+        axis,
+        values: new Set(buttons.filter((b) => b.ariaPressed === 'true').map((b) => b.dataset.value)),
+      }));
+
+      for (const node of root.querySelectorAll<HTMLElement>('.node')) {
+        node.hidden = !active.every(({ axis, values }) => values.has(node.dataset[axis]));
+      }
+
+      for (const column of root.querySelectorAll<HTMLElement>('.column')) {
+        const shown = [...column.querySelectorAll<HTMLElement>('.node')].filter((n) => !n.hidden);
+        const done = shown.filter((n) => n.dataset.status === 'done').length;
+        const meta = column.querySelector('.column-meta');
+        if (meta) meta.textContent = `${done} / ${shown.length}`;
+      }
+    };
+
+    // Clicking a chip selects it *alone* on its axis rather than toggling it
+    // off — asking for "just the planned ones" is the common move, and doing
+    // that by switching the other two off is two clicks too many. Clicking the
+    // chip that is already alone clears the axis back to all, which is the only
+    // way back and so must be the same click.
+    for (const { buttons } of legends) {
+      for (const button of buttons) {
+        button.addEventListener('click', () => {
+          const alreadySolo =
+            button.ariaPressed === 'true' && buttons.every((b) => b === button || b.ariaPressed === 'false');
+
+          for (const b of buttons) {
+            b.ariaPressed = String(alreadySolo || b === button);
+          }
+          apply();
+        });
+      }
+    }
+  }
+</script>

--- a/docs/site/src/content.config.ts
+++ b/docs/site/src/content.config.ts
@@ -1,7 +1,43 @@
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
+import { file } from 'astro/loaders';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
+/** Shared by goals and nodes. Hand-set on both; nothing is derived. */
+const status = z.enum(['planned', 'in-progress', 'done']);
+
+/**
+ * `design` and `implementation` are stages of one node, split into siblings
+ * only where the two halves differ in status. `organization` is a kind of
+ * work rather than a stage, and reads across every column.
+ */
+const category = z.enum(['design', 'implementation', 'organization']);
+
+const roadmapNode = z.object({
+  name: z.string(),
+  category,
+  status,
+  /** GitHub issue numbers. A link only — nothing reads their state. */
+  issues: z.array(z.number().int().positive()).optional(),
+  /** Rendered on `in-progress` nodes only. */
+  note: z.string().optional(),
+});
+
+const roadmapGoal = z.object({
+  /** Left-to-right column order. The loader does not promise key order. */
+  order: z.number().int().positive(),
+  name: z.string(),
+  status,
+  target: z.string().optional(),
+  /** Closing line for a column that is deliberately unfinished. */
+  trailer: z.string().optional(),
+  nodes: z.array(roadmapNode).min(1),
+});
+
 export const collections = {
   docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  roadmap: defineCollection({
+    loader: file('src/content/roadmap/roadmap.yml'),
+    schema: roadmapGoal,
+  }),
 };

--- a/docs/site/src/content/docs/roadmap.mdx
+++ b/docs/site/src/content/docs/roadmap.mdx
@@ -1,0 +1,73 @@
+---
+title: Roadmap
+description: What is built, what is being built, and what comes next.
+tableOfContents: false
+---
+
+import Roadmap from '../../components/Roadmap.astro';
+
+<Roadmap />
+
+## How to read it
+
+Columns read left to right, but **left to right is a reading order, not a gate**. They overlap:
+work starts in `MVP` while `Foundation` still has planned nodes in it, and a column's
+`done / total` reports progress rather than granting the next column permission to begin.
+
+- **Foundation** is the platform everything else stands on — schema, auth, tokens, Storybook, CI,
+  deployment. It is _incomplete by intent_: it carries all platform work whether or not it is
+  finished, so it never reads as fully done.
+- **MVP** is the product surface, cut **by page** rather than by capability. API work is invisible,
+  living inside the page node it serves; the two exceptions are `Write-side domain model`, which
+  serves no single page, and `Purchase & confirmation flow`, which is named because it is the
+  product's core loop.
+- **Beyond** is what comes after that loop works. It is deliberately thin and gets written when
+  MVP is real.
+
+A node is roughly a page's worth of work. Components are below this board's resolution and do not
+appear on it.
+
+## Status
+
+Status is set by hand on every node — nothing is derived from issues, branches, or the column
+around it. The round chips above filter the board by status.
+
+- **planned** — not started.
+- **in progress** — started.
+- **done** — _good enough to build on today_. Not "finished forever": the design system will grow
+  for as long as the product does, and it still reads `done`, because nothing is waiting on it.
+
+## Category
+
+The colour on a node's left border is its **category**, an axis separate from status. The square
+chips above filter the board by category.
+
+Both rows of chips work the same way: clicking one shows **only** that value, and clicking it again
+brings the rest back. The two rows combine, so `design` plus `planned` shows the design work that
+has not started.
+
+- **design** and **implementation** are two _stages_ of the same node. They only appear as separate
+  nodes where the two halves are in different states — designing the landing page is done while
+  building it is not. Where both halves share a status, one node says it.
+- **organization** is not a stage but a _kind_ of work — the parts of shipping that are not code.
+  It reads across every column rather than sitting in one.
+
+:::note
+The organization nodes are the least settled part of this board. Every column was filled by walking
+the code, so these four were sketched in afterwards to mark that the work exists — treat their
+names as a starting point rather than a commitment.
+:::
+
+## Issues
+
+The `#nnn` links point at [GitHub issues](https://github.com/potrzebnik/potrzebnik/issues). They
+are links and nothing more: closing an issue does not move a node, and a node with no issue is
+simply unfiled work rather than a gap in the plan. Issue titles are in Polish and node names are in
+English — a node names a page, an issue names a slice of it, so the two do not line up one to one.
+
+## Editing it
+
+The content is [`docs/site/src/content/roadmap/roadmap.yml`](https://github.com/potrzebnik/potrzebnik/blob/main/docs/site/src/content/roadmap/roadmap.yml),
+validated by the `roadmap` collection in `src/content.config.ts` and rendered by
+`src/components/Roadmap.astro`. Edit the YAML; the schema will reject a status or category it does
+not recognise at build time.

--- a/docs/site/src/content/docs/zasady-wspolpracy.mdx
+++ b/docs/site/src/content/docs/zasady-wspolpracy.mdx
@@ -1,0 +1,86 @@
+---
+title: Zasady współpracy
+description: 'Zasady obowiązujące cały zespół: ownership tasków, obecność na spotkaniach i review.'
+---
+
+Ta strona jest wyjątkiem od reguły „dokumentacja po angielsku”: dotyczy pracy
+zespołu, więc jest po polsku. Zasady obowiązują każdego, bez wyjątków.
+
+## Ownership taska
+
+Osoba przypisana do taska jest za niego odpowiedzialna: za samą pracę
+i za aktualizowanie statusu na
+[boardzie](https://github.com/orgs/potrzebnik/projects/1). Board ma odzwierciedlać stan
+rzeczywisty; nikt nie aktualizuje go za Ciebie.
+
+- Aktualizuję status taska na boardzie sam, na bieżąco.
+- Mam **maksymalnie dwa** taski w toku. Gdy oba stoją, nie biorę trzeciego,
+  tylko zgłaszam blokadę.
+- **Raz w tygodniu** wrzucam update o swojej pracy jako komentarz do taska,
+  nie na czacie i nie ustnie na spotkaniu.
+
+Komentarz zostaje przy tasku, więc historia jest w jednym miejscu i każdy może
+ją odczytać bez pytania. Zgłoszenie braku postępu to nie przyznanie się do
+porażki, tylko obowiązek: tech lead decyduje, czy ktoś task przejmie, czy da się
+Cię wesprzeć inaczej. Milczenie jest jedynym błędem.
+
+:::caution[Do ustalenia]
+Definition of Done: co dokładnie musi być spełnione, żeby przesunąć task na
+review i na done. Bez tego każdy interpretuje statusy po swojemu. Do ustalenia
+zespołowo.
+:::
+
+## Spotkania i obecność
+
+Spotkania w Google Kalendarzu są sposobem informowania o obecności.
+
+- Oznaczam odpowiedź (będę / nie będę) przed spotkaniem.
+- Trzymam się tego, co zadeklarowałem.
+- Gdy plany się zmieniają, zmieniam odpowiedź w kalendarzu, zanim spotkanie
+  się zacznie.
+
+## Code review
+
+Każdy deweloper robi review innym osobom. Review nie jest zadaniem wyłącznie
+tech leada.
+
+Jako autor PR-a:
+
+- PR, nad którym jeszcze pracuję, trzymam w drafcie. Zdjęcie draftu oznacza:
+  PR jest gotowy do review.
+- Do review przypisany jest zespół `potrzebnik/devs`. Robi to automatycznie
+  CODEOWNERS w momencie zdjęcia draftu; sprawdzam tylko, czy request faktycznie
+  wisi. „Niech ktoś zerknie” nie jest prośbą o review, bo nikt się wtedy nie
+  czuje wskazany.
+
+Jako reviewer:
+
+- Czytam kod, którego dotyczy uwaga, zanim ją napiszę.
+- Gdy review powstaje z pomocą AI, weryfikuję **każdą uwagę** przed dodaniem
+  komentarza.
+
+Komentarz, który wkleiłeś bez weryfikacji, jest Twoim komentarzem i Twoją
+odpowiedzialnością.
+
+## Zgłaszanie długu technicznego
+
+Dług techniczny zauważony przy pracy nie znika przez to, że go ominąłeś —
+znika, gdy jest zapisany. Miejscem zapisu jest GitHub issue z etykietą
+[`tech-debt`](https://github.com/potrzebnik/potrzebnik/issues?q=is%3Aissue%20state%3Aopen%20label%3Atech-debt),
+nie komentarz w kodzie, nie wiadomość na czacie i nie „trzeba to kiedyś
+poprawić" na spotkaniu.
+
+- Gdy trafiam na dług techniczny, zakładam issue z etykietą `tech-debt` —
+  od razu, nie „po skończeniu taska".
+- Nie naprawiam długu w PR-ze, który dotyczy czego innego. Issue tak,
+  poprawka osobno.
+- W issue piszę: **gdzie** (plik, moduł), **co** jest nie tak i **dlaczego**
+  to przeszkadza. Bez „dlaczego" nikt nie umie ocenić priorytetu.
+
+Issue z etykietą to nie zobowiązanie, że ktoś to zaraz zrobi — to zapis, dzięki
+któremu dług da się zobaczyć i świadomie zaplanować albo świadomie odłożyć.
+
+:::caution[Do ustalenia]
+SLA na review: w jakim czasie przypisana osoba ma odpowiedzieć na PR i co robi
+autor, gdy ten czas minie. Do ustalenia zespołowo.
+:::

--- a/docs/site/src/content/roadmap/roadmap.yml
+++ b/docs/site/src/content/roadmap/roadmap.yml
@@ -1,0 +1,160 @@
+# The roadmap's single source of content. Rendered by src/components/Roadmap.astro
+# and validated by the `roadmap` collection in src/content.config.ts.
+#
+# Shape: a mapping of goal id -> goal. `order` fixes the left-to-right column
+# order; object key order is not something the loader promises.
+#
+# Editing rules:
+#   - `status` is set by hand, on goals and nodes alike. Nothing is derived.
+#   - `done` means "good enough to build on today", not "finished forever".
+#   - `category` is required. `design` and `implementation` are stages of one
+#     node and are split into siblings only where the two halves differ in
+#     status; `organization` is a kind of work, not a stage.
+#   - The four `organization` nodes came across from the 008 prototype, where
+#     they were invented placeholders rather than decided work. Their names are
+#     a starting point, not a commitment.
+#   - `note` renders on any node that has one. Explanatory prose about
+#     the roadmap itself — what a column means, what a status means — belongs in
+#     docs/roadmap.mdx, not here. A goal renders as name + count + trailer.
+
+foundation:
+  order: 1
+  name: Foundation
+  status: in-progress
+  nodes:
+    - name: App skeleton
+      category: implementation
+      status: done
+    - name: Database schema & migrations
+      category: implementation
+      status: done
+    - name: Authentication backend
+      category: implementation
+      status: done
+      issues: [80]
+    - name: Design system & tokens
+      category: design
+      status: done
+    - name: Storybook component workshop
+      category: implementation
+      status: done
+      issues: [77]
+    - name: Documentation site
+      category: implementation
+      status: done
+    - name: CI quality gate
+      category: implementation
+      status: done
+      issues: [61]
+    - name: Write-side domain model
+      category: implementation
+      status: in-progress
+      note: entities and value objects exist; no behaviour yet
+    - name: Sign-in / sign-up UI
+      category: implementation
+      status: planned
+      issues: [13, 15, 40]
+    - name: Route protection & roles
+      category: implementation
+      status: planned
+      note: no roles model yet
+      issues: [42]
+    - name: Transactional email
+      category: implementation
+      status: planned
+      note: provider, message templates, deploy-time verification
+      issues: [78, 71]
+    - name: App deployment
+      category: implementation
+      status: planned
+      note: only the docs site deploys today
+    - name: 'Legal copy: terms & privacy'
+      category: organization
+      status: planned
+    - name: First partner organizations
+      category: organization
+      status: planned
+      note: someone has to agree to use this
+
+mvp:
+  order: 2
+  name: MVP
+  status: in-progress
+  nodes:
+    - name: Landing page
+      category: design
+      status: done
+    - name: Landing page
+      category: implementation
+      status: in-progress
+      note: sections built; header/footer mounted; hero route still placeholder
+      issues: [22, 79, 66, 65, 24, 29, 76]
+    - name: Public need list
+      category: implementation
+      status: planned
+      note: includes basic filtering
+      issues: [16]
+    - name: Need detail
+      category: implementation
+      status: planned
+      issues: [12]
+    - name: Purchase & confirmation flow
+      category: implementation
+      status: planned
+      note: donor marks purchased, organization confirms; notifies by email
+      issues: [11, 45, 44]
+    - name: Organization pages
+      category: implementation
+      status: planned
+      note: list and profile
+    - name: Static pages
+      category: implementation
+      status: planned
+      note: about, contact, FAQ, privacy, terms
+    - name: Organization dashboard
+      category: implementation
+      status: planned
+      note: includes basic user administration
+    - name: Need create & edit
+      category: implementation
+      status: planned
+      issues: [14, 43]
+    - name: Fulfilment history
+      category: implementation
+      status: planned
+      note: tables exist, nothing reads them
+    - name: Our team
+      category: design
+      status: done
+    - name: Contact with us
+      category: design
+      status: done
+    - name: Add your organization
+      category: design
+      status: done
+    - name: 'Component alignment: Storybook <-> code'
+      category: design
+      status: planned
+      note: comments on Figma
+    - name: Mailing templates
+      category: organization
+      status: in-progress
+    - name: Launch communication
+      category: organization
+      status: planned
+      note: telling anyone this exists
+
+beyond:
+  order: 3
+  name: Beyond
+  status: planned
+  trailer: The rest of this column is not written yet.
+  nodes:
+    - name: Platform moderation
+      category: implementation
+      status: planned
+      note: blocking users; approach unresolved
+      issues: [52]
+    - name: Marketing & social presence
+      category: organization
+      status: planned

--- a/docs/site/src/styles/custom.css
+++ b/docs/site/src/styles/custom.css
@@ -36,3 +36,25 @@
 .sl-markdown-content :is(h1, h2, h3, h4, h5, h6) code {
   font-size: 0.9em;
 }
+
+/* Roadmap colours. Theme-level and reusable, so they live here rather than in
+   `Roadmap.astro` — and this is the only file in the docs site allowed to
+   contain a hex literal. Two independent channels: category on a node's left
+   border, status on its pill. The hues are kept apart so the channels stay
+   separable. Starlight toggles `[data-theme]` on <html>; the light values are
+   darkened for contrast against a white background. */
+:root {
+  --roadmap-category-design: #b07cff;
+  --roadmap-category-implementation: #35b8d4;
+  --roadmap-category-organization: #e2568a;
+  --roadmap-status-done: #3fae7a;
+  --roadmap-status-in-progress: #d8942a;
+}
+
+[data-theme='light'] {
+  --roadmap-category-design: #7c3fd6;
+  --roadmap-category-implementation: #0d7d95;
+  --roadmap-category-organization: #b81f57;
+  --roadmap-status-done: #1f7d51;
+  --roadmap-status-in-progress: #97620f;
+}


### PR DESCRIPTION
## Summary
- Add CODEOWNERS
- Add public roadmap page/content collection (Roadmap.astro, roadmap.mdx, roadmap.yml)
- Add contributing/collaboration doc (zasady-wspolpracy.mdx)
- Minor design token additions in custom.css

## Test plan
- [x] `pnpm run lint` / `lint:css`
- [x] `pnpm run type-check`
- [x] `pnpm run test` (unit)
- [ ] Review docs site build/preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqmPtGuqrMotvtA2S1Rffg